### PR TITLE
Add headers as an option in the existing API

### DIFF
--- a/Classes/Core Modules/RPJSRequest.m
+++ b/Classes/Core Modules/RPJSRequest.m
@@ -12,34 +12,118 @@
 @implementation RPJSRequest
 
 + (void)setupInContext:(JSContext *)context {
-    context[@"__request_get"] = ^(NSString *url, JSValue *successCallback, JSValue *errorCallback) {
-        [[RPJSRequest sharedManager] GET:url parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
-            NSString *responseString = [[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding];
-            [successCallback callWithArguments:@[ responseString ]];
-        } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-            [errorCallback callWithArguments:@[ [[error userInfo] description] ]];
-        }];
+    context[@"__request_get"] = ^(JSValue *urlValue, JSValue *successCallback, JSValue *errorCallback) {
+        NSString *urlString = [self urlStringFromURLValue:urlValue];
+        NSDictionary *headers = [self headersFromURLValue:urlValue];
+
+        AFHTTPRequestOperation *operation = [self operationWithURLString:urlString httpMethod:@"GET" headers:headers parameters:@{} successCallback:successCallback errorCallback:errorCallback];
+        if (operation) {
+            [[self sharedQueue] addOperation:operation];
+        }
     };
-    context[@"__request_post"] = ^(NSString *url, NSDictionary *parameters, JSValue *successCallback, JSValue *errorCallback) {
-        [[RPJSRequest sharedManager] POST:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
-            NSString *responseString = [[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding];
-            [successCallback callWithArguments:@[ responseString ]];
-        } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-            [errorCallback callWithArguments:@[ [[error userInfo] description] ]];
-        }];
+    context[@"__request_post"] = ^(JSValue *urlValue, NSDictionary *parameters, JSValue *successCallback, JSValue *errorCallback) {
+        NSString *urlString = [self urlStringFromURLValue:urlValue];
+        NSDictionary *headers = [self headersFromURLValue:urlValue];
+
+        AFHTTPRequestOperation *operation = [self operationWithURLString:urlString httpMethod:@"POST" headers:headers parameters:parameters successCallback:successCallback errorCallback:errorCallback];
+        if (operation) {
+            [[self sharedQueue] addOperation:operation];
+        }
     };
 }
 
 #pragma mark - Private
 
-+ (AFHTTPRequestOperationManager *)sharedManager {
++ (NSOperationQueue *)sharedQueue {
     static dispatch_once_t once;
-    static AFHTTPRequestOperationManager *requestManager;
+    static NSOperationQueue *queue;
     dispatch_once(&once, ^{
-        requestManager = [AFHTTPRequestOperationManager manager];
-        requestManager.responseSerializer = [[AFHTTPResponseSerializer alloc] init];
+        queue = [[NSOperationQueue alloc] init];
+        queue.maxConcurrentOperationCount = NSOperationQueueDefaultMaxConcurrentOperationCount;
+        queue.qualityOfService = NSQualityOfServiceUserInitiated;
     });
-    return requestManager;
+    return queue;
+}
+
++ (AFHTTPRequestOperation *)operationWithURLString:(NSString *)urlString httpMethod:(NSString *)httpMethod headers:(NSDictionary *)headers parameters:(NSDictionary *)parameters successCallback:(JSValue *)successCallback errorCallback:(JSValue *)errorCallback {
+    if (!urlString || urlString.length == 0 || !httpMethod || httpMethod.length == 0) {
+        return nil;
+    }
+
+    AFJSONRequestSerializer *requestSerializer = [[AFJSONRequestSerializer alloc] init];
+    NSError *requestConstructionError;
+    NSMutableURLRequest *request = [requestSerializer requestWithMethod:httpMethod URLString:urlString parameters:parameters error:&requestConstructionError];
+    if (requestConstructionError) {
+        return nil;
+    }
+
+    NSMutableDictionary *mutableHeaders = [[self defaultHeaders] mutableCopy];
+    [mutableHeaders addEntriesFromDictionary:headers];
+    for (NSString *headerName in mutableHeaders) {
+        NSString *header = mutableHeaders[headerName];
+        [request setValue:header forHTTPHeaderField:headerName];
+    }
+
+    AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    operation.responseSerializer = [AFCompoundResponseSerializer compoundSerializerWithResponseSerializers:@[ [[AFHTTPResponseSerializer alloc] init], [[AFJSONResponseSerializer alloc] init] ]];
+    [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *completedOperation, id responseObject) {
+        NSString *responseString = [[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding];
+        if (responseString) {
+            [successCallback callWithArguments:@[ responseString ]];
+        }
+    } failure:^(AFHTTPRequestOperation *failedOperation, NSError *error) {
+        [errorCallback callWithArguments:@[ [[error userInfo] description] ?: @"" ]];
+    }];
+
+    return operation;
+}
+
+/**
+ *  Extracts the URL from the first argument (optionally a JS Object)
+ *
+ *  @param urlValue The first argument
+ *
+ *  @return A URL string or nil
+ */
++ (NSString *)urlStringFromURLValue:(JSValue *)urlValue {
+    NSString *urlString;
+
+    if ([urlValue isString]) {
+        urlString = [urlValue toString];
+    }
+    else if ([urlValue isObject]) {
+        NSDictionary *options = [urlValue toDictionary];
+        urlString = options[@"url"];
+    }
+
+    return urlString;
+}
+
+/**
+ *  Extracts the headers from the first argument (optionally a JS Object)
+ *
+ *  @param urlValue The first argument
+ *
+ *  @return A dictionary of headers, at worst empty and non-nil
+ */
++ (NSDictionary *)headersFromURLValue:(JSValue *)urlValue {
+    NSDictionary *headers = @{};
+
+    if ([urlValue isObject]) {
+        NSDictionary *options = [urlValue toDictionary];
+        headers = options[@"headers"];
+        if (!headers || [headers isEqual:[NSNull null]]) {
+            headers = @{};
+        }
+    }
+
+    return headers;
+}
+
++ (NSDictionary *)defaultHeaders {
+    return @{
+        @"Accept": @"application/json"
+    };
 }
 
 @end

--- a/Example/iOS/Podfile.lock
+++ b/Example/iOS/Podfile.lock
@@ -1,27 +1,27 @@
 PODS:
-  - AFNetworking (2.5.0):
-    - AFNetworking/NSURLConnection (= 2.5.0)
-    - AFNetworking/NSURLSession (= 2.5.0)
-    - AFNetworking/Reachability (= 2.5.0)
-    - AFNetworking/Security (= 2.5.0)
-    - AFNetworking/Serialization (= 2.5.0)
-    - AFNetworking/UIKit (= 2.5.0)
-  - AFNetworking/NSURLConnection (2.5.0):
+  - AFNetworking (2.5.3):
+    - AFNetworking/NSURLConnection (= 2.5.3)
+    - AFNetworking/NSURLSession (= 2.5.3)
+    - AFNetworking/Reachability (= 2.5.3)
+    - AFNetworking/Security (= 2.5.3)
+    - AFNetworking/Serialization (= 2.5.3)
+    - AFNetworking/UIKit (= 2.5.3)
+  - AFNetworking/NSURLConnection (2.5.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.0):
+  - AFNetworking/NSURLSession (2.5.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.0)
-  - AFNetworking/Security (2.5.0)
-  - AFNetworking/Serialization (2.5.0)
-  - AFNetworking/UIKit (2.5.0):
+  - AFNetworking/Reachability (2.5.3)
+  - AFNetworking/Security (2.5.3)
+  - AFNetworking/Serialization (2.5.3)
+  - AFNetworking/UIKit (2.5.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - Kiwi (2.3.1)
-  - RPJSContext (1.1.0):
+  - RPJSContext (2.1.1):
     - AFNetworking (~> 2.2)
 
 DEPENDENCIES:
@@ -33,8 +33,8 @@ EXTERNAL SOURCES:
     :path: ../../
 
 SPEC CHECKSUMS:
-  AFNetworking: 0f54cb5d16ce38c1b76948faffb8d5fb705021c7
-  Kiwi: 73e1400209055ee9c8ba78c6012b6b642d0fb9f7
-  RPJSContext: 963c6f305ae32063c240687a954dbb49d6bc9094
+  AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
+  Kiwi: f038a6c61f7a9e4d7766bff5717aa3b3fdb75f55
+  RPJSContext: 826e8e3e90e8d1af5a2969ff9512989d8ff56f82
 
 COCOAPODS: 0.35.0


### PR DESCRIPTION
Allow users to pass either a URL string or an object with the string and optional headers. Updated tests and changed them to use the JSC bridge API instead of just evaluating code. This makes it a lot easier to debug what might be going wrong when a test fails.

This design was based on https://github.com/request/request and although a (potentially big) object argument is a little gross it allows more flexibility to make changes to the API easily and works well with the JSC bridge. Would be nice to also move the parameters argument in there sometime in the future.

e.g.

```js
Request.get('http://httpbin.org/get')
  .then(JSON.parse)
  .then(function(result) {
    console.log(result.json.headers['Accept']);
  }
)

// or

Request.get({url: 'http://httpbin.org/get', headers: {'Accept': 'application/json'}})
  .then(JSON.parse)
  .then(function(result) {
    console.log(result.json.headers['Accept']);
  }
)
```